### PR TITLE
skip over unknown entities and signals in constant combinator

### DIFF
--- a/blueprintstring/blueprintstring.lua
+++ b/blueprintstring/blueprintstring.lua
@@ -98,13 +98,23 @@ function fix_entities(array)
 					if (uint32 and uint32 >= 2147483648 and uint32 < 4294967296) then
 						filter.count = uint32 - 4294967296
 					end
+					-- remove unknown signals
+				  	if filter.signal.type == "virtual" and not game.virtual_signal_prototypes[filter.signal.name] then
+            					table.remove(entity.control_behavior.filters, index)
+					elseif filter.signal.type == "item" and not game.item_prototypes[filter.signal.name] then
+            					table.remove(entity.control_behavior.filters, index)
+         				elseif filter.signal.type == "fluid" and not game.fluid_prototypes[filter.signal.name] then
+            					table.remove(entity.control_behavior.filters, index)
+					end
 				end
 			end
-
-			-- Add entity number
-			entity.entity_number = count
-			entities[count] = entity
-			count = count + 1
+			
+			if game.entity_prototypes[entity.name] then --skip over unknown entities
+				-- Add entity number
+				entity.entity_number = count
+				entities[count] = entity
+				count = count + 1
+			end
 		end
 	end
 	return entities

--- a/blueprintstring/blueprintstring.lua
+++ b/blueprintstring/blueprintstring.lua
@@ -93,18 +93,18 @@ function fix_entities(array)
 
 			-- Factorio 0.13 format
 			if (entity.name == "constant-combinator" and entity.control_behavior and type(entity.control_behavior) == 'table' and entity.control_behavior.filters and type(entity.control_behavior.filters) == 'table') then
-				for _, filter in pairs(entity.control_behavior.filters) do
+				for index, filter in pairs(entity.control_behavior.filters) do
 					local uint32 = tonumber(filter.count)
 					if (uint32 and uint32 >= 2147483648 and uint32 < 4294967296) then
 						filter.count = uint32 - 4294967296
 					end
 					-- remove unknown signals
-				  	if filter.signal.type == "virtual" and not game.virtual_signal_prototypes[filter.signal.name] then
-            					table.remove(entity.control_behavior.filters, index)
-					elseif filter.signal.type == "item" and not game.item_prototypes[filter.signal.name] then
-            					table.remove(entity.control_behavior.filters, index)
-         				elseif filter.signal.type == "fluid" and not game.fluid_prototypes[filter.signal.name] then
-            					table.remove(entity.control_behavior.filters, index)
+          if filter.signal.type == "virtual" and not game.virtual_signal_prototypes[filter.signal.name] then
+            table.remove(entity.control_behavior.filters, index)
+          elseif filter.signal.type == "item" and not game.item_prototypes[filter.signal.name] then
+            table.remove(entity.control_behavior.filters, index)
+          elseif filter.signal.type == "fluid" and not game.fluid_prototypes[filter.signal.name] then
+            table.remove(entity.control_behavior.filters, index)
 					end
 				end
 			end


### PR DESCRIPTION
Getting the unknown entity errors when importing blueprints from different saves with different mods bothered me.
So I changed the library to skip over unknown game prototypes. 

It's not yet perfect as decider or arithmetic combinators could still be set to unknown.